### PR TITLE
relax activemodel version dependency

### DIFF
--- a/certificate_authority.gemspec
+++ b/certificate_authority.gemspec
@@ -67,18 +67,18 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activemodel>, ["~> 3.0.6"])
+      s.add_runtime_dependency(%q<activemodel>, [">= 3.0.6"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<activemodel>, ["~> 3.0.6"])
+      s.add_dependency(%q<activemodel>, [">= 3.0.6"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<activemodel>, ["~> 3.0.6"])
+    s.add_dependency(%q<activemodel>, [">= 3.0.6"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])


### PR DESCRIPTION
Any specific reason the activemodel dependency is pinned at 3.0.x?

I'm using the certificate_authority gem in a rails 3.2.x app and its working for me so far.

If there is no real need to stick to active model 3.0.x please pull and release a new version.
