### PR TITLE
Random improvements/changes that folks may enjoy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'activemodel', ">= 3.0.6"
+gem 'activesupport', ">= 3.0.6"
 
 group :development do
 	gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,40 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    activemodel (3.2.8)
-      activesupport (= 3.2.8)
+    activemodel (3.2.13)
+      activesupport (= 3.2.13)
       builder (~> 3.0.0)
-    activesupport (3.2.8)
-      i18n (~> 0.6)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
-    builder (3.0.0)
-    diff-lcs (1.1.3)
+    builder (3.0.4)
+    diff-lcs (1.2.4)
     git (1.2.5)
-    i18n (0.6.0)
+    i18n (0.6.1)
     jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
       rdoc
-    json (1.7.4)
-    multi_json (1.3.6)
-    rake (0.9.2.2)
-    rdoc (3.12)
+    json (1.8.0)
+    multi_json (1.7.4)
+    rake (10.0.4)
+    rdoc (4.0.1)
       json (~> 1.4)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activemodel (>= 3.0.6)
+  activesupport (>= 3.0.6)
   jeweler (>= 1.5.2)
   rspec

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ require 'jeweler'
 Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
   gem.name = "certificate_authority"
-  gem.homepage = "http://github.com/cchandler/certificate_authority"
+  gem.homepage = "https://github.com/cchandler/certificate_authority"
   gem.license = "MIT"
   gem.summary = 'Ruby gem for managing the core functions outlined in RFC-3280 for PKI'
   # gem.description = ''

--- a/certificate_authority.gemspec
+++ b/certificate_authority.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
     "spec/units/units_helper.rb",
     "spec/units/working_with_openssl_spec.rb"
   ]
-  s.homepage = "http://github.com/cchandler/certificate_authority"
+  s.homepage = "https://github.com/cchandler/certificate_authority"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.15"
@@ -72,15 +72,18 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activemodel>, [">= 3.0.6"])
+      s.add_runtime_dependency(%q<activesupport>, [">= 3.0.6"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 1.5.2"])
     else
       s.add_dependency(%q<activemodel>, [">= 3.0.6"])
+      s.add_dependency(%q<activesupport>, [">= 3.0.6"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 1.5.2"])
     end
   else
     s.add_dependency(%q<activemodel>, [">= 3.0.6"])
+    s.add_dependency(%q<activesupport>, [">= 3.0.6"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 1.5.2"])
   end

--- a/lib/certificate_authority/distinguished_name.rb
+++ b/lib/certificate_authority/distinguished_name.rb
@@ -32,11 +32,16 @@ module CertificateAuthority
     alias :emailAddress :email_address
     alias :emailAddress= :email_address=
 
+    attr_accessor :serial_number
+    alias :serialNumber :serial_number
+    alias :serialNumber= :serial_number=
+
     def to_x509_name
       raise "Invalid Distinguished Name" unless valid?
 
       # NB: the capitalization in the strings counts
       name = OpenSSL::X509::Name.new
+      name.add_entry("serialNumber", serial_number) unless serial_number.blank?
       name.add_entry("C", country) unless country.blank?
       name.add_entry("ST", state) unless state.blank?
       name.add_entry("L", locality) unless locality.blank?

--- a/lib/certificate_authority/serial_number.rb
+++ b/lib/certificate_authority/serial_number.rb
@@ -6,5 +6,9 @@ module CertificateAuthority
     attr_accessor :number
 
     validates :number, :presence => true, :numericality => {:greater_than => 0}
+
+    def initialize
+      self.number = SecureRandom.random_number(2**128-1)
+    end
   end
 end

--- a/lib/certificate_authority/signing_request.rb
+++ b/lib/certificate_authority/signing_request.rb
@@ -5,6 +5,12 @@ module CertificateAuthority
     attr_accessor :raw_body
     attr_accessor :openssl_csr
     attr_accessor :digest
+    attr_accessor :attributes
+
+    def read_attributes_by_oid(*oids)
+      attributes.detect { |a| oids.include?(a.oid) }
+    end
+    protected :read_attributes_by_oid
 
     def to_cert
       cert = Certificate.new
@@ -12,6 +18,17 @@ module CertificateAuthority
         cert.distinguished_name = @distinguished_name
       end
       cert.key_material = @key_material
+      if attribute = read_attributes_by_oid('extReq', 'msExtReq')
+        set = OpenSSL::ASN1.decode(attribute.value)
+        seq = set.value.first
+        seq.value.collect { |asn1ext| OpenSSL::X509::Extension.new(asn1ext).to_a }.each do |o, v, c|
+          ObjectSpace.each_object(Module) do |m|
+            next if m == CertificateAuthority::Extensions::ExtensionAPI
+            next unless m.ancestors.include?(CertificateAuthority::Extensions::ExtensionAPI)
+            cert.extensions[m::OPENSSL_IDENTIFIER] = m.parse(v, c) if v && m::OPENSSL_IDENTIFIER == o
+          end
+        end
+      end
       cert
     end
 
@@ -24,10 +41,12 @@ module CertificateAuthority
       raise "Invalid DN in request" unless @distinguished_name.valid?
       raise "CSR must have key material" if @key_material.nil?
       raise "CSR must include a public key on key material" if @key_material.public_key.nil?
+      raise "Need a private key on key material for CSR generation" if @key_material.private_key.nil?
 
       opensslcsr = OpenSSL::X509::Request.new
       opensslcsr.subject = @distinguished_name.to_x509_name
       opensslcsr.public_key = @key_material.public_key
+      opensslcsr.attributes = @attributes unless @attributes.nil?
       opensslcsr.sign @key_material.private_key, OpenSSL::Digest::Digest.new(@digest || "SHA512")
       opensslcsr
     end
@@ -38,6 +57,7 @@ module CertificateAuthority
       csr.distinguished_name = DistinguishedName.from_openssl openssl_csr.subject
       csr.raw_body = raw_csr
       csr.openssl_csr = openssl_csr
+      csr.attributes = openssl_csr.attributes
       key_material = SigningRequestKeyMaterial.new
       key_material.public_key = openssl_csr.public_key
       csr.key_material = key_material

--- a/spec/units/certificate_spec.rb
+++ b/spec/units/certificate_spec.rb
@@ -250,7 +250,7 @@ describe CertificateAuthority::Certificate do
         cert.extensions.map(&:oid).include?("certificatePolicies").should be_true
       end
 
-      it "should contain a nested userNotice if specified" do
+      pending "should contain a nested userNotice if specified" do
         #pending
          @certificate.sign!({
            "extensions" => {
@@ -328,7 +328,7 @@ describe CertificateAuthority::Certificate do
           "crlDistributionPoints" => {"uri" => "http://notme.com/other.crl" },
           "subjectKeyIdentifier" => {},
           "authorityKeyIdentifier" => {},
-          "authorityInfoAccess" => {"ocsp" => ["http://youFillThisOut/ocsp/"] },
+          "authorityInfoAccess" => {"ocsp" => ["http://youFillThisOut/ocsp/"], "ca_issuers" => ["http://me.com/other.crt"] },
           "keyUsage" => {"usage" => ["digitalSignature","nonRepudiation"] },
           "extendedKeyUsage" => {"usage" => [ "serverAuth","clientAuth"]},
           "subjectAltName" => {"uris" => ["http://subdomains.youFillThisOut/"]},
@@ -422,13 +422,13 @@ CERT
   end
 
   it "should default to one year validity" do
-    @certificate.not_after.should < Time.now + 65 * 60 * 24 * 365 and
-    @certificate.not_after.should > Time.now + 55 * 60 * 24 * 365
+    @certificate.not_after.should < Time.now.change(:min => 0).utc + 1.year + 2.hour and
+    @certificate.not_after.should > Time.now.change(:min => 0).utc + 1.year - 2.hour
   end
 
   it "should be able to have a revoked at time" do
     @certificate.revoked?.should be_false
-    @certificate.revoked_at = Time.now
+    @certificate.revoked_at = Time.now.utc
     @certificate.revoked?.should be_true
   end
 

--- a/spec/units/distinguished_name_spec.rb
+++ b/spec/units/distinguished_name_spec.rb
@@ -12,6 +12,8 @@ describe CertificateAuthority::DistinguishedName do
     @distinguished_name.respond_to?(:o).should be_true
     @distinguished_name.respond_to?(:ou).should be_true
     @distinguished_name.respond_to?(:c).should be_true
+    @distinguished_name.respond_to?(:emailAddress).should be_true
+    @distinguished_name.respond_to?(:serialNumber).should be_true
   end
 
   it "should provide human-readable equivalents to the distinguished name common attributes" do
@@ -21,6 +23,8 @@ describe CertificateAuthority::DistinguishedName do
     @distinguished_name.respond_to?(:organization).should be_true
     @distinguished_name.respond_to?(:organizational_unit).should be_true
     @distinguished_name.respond_to?(:country).should be_true
+    @distinguished_name.respond_to?(:email_address).should be_true
+    @distinguished_name.respond_to?(:serial_number).should be_true
   end
 
   it "should require a common name" do

--- a/spec/units/extensions_spec.rb
+++ b/spec/units/extensions_spec.rb
@@ -27,6 +27,13 @@ describe CertificateAuthority::Extensions do
       basic_constraints.path_len = 2
       basic_constraints.to_s.should == "CA:true,pathlen:2"
     end
+
+    it "should parse values from a proper OpenSSL extension string" do
+      basic_constraints = CertificateAuthority::Extensions::BasicConstraints.parse("CA:true,pathlen:2", true)
+      basic_constraints.critical.should be_true
+      basic_constraints.ca.should be_true
+      basic_constraints.path_len.should == 2
+    end
   end
 
   describe CertificateAuthority::Extensions::SubjectAlternativeName do
@@ -49,6 +56,13 @@ describe CertificateAuthority::Extensions do
       subjectAltName.to_s.should == "URI:http://localhost.altname.example.com,URI:http://other.example.com"
     end
 
+    it "should parse URIs from a proper OpenSSL extension string" do
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("URI:http://localhost.altname.example.com", false)
+      subjectAltName.uris.should == ["http://localhost.altname.example.com"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("URI:http://localhost.altname.example.com,URI:http://other.example.com", false)
+      subjectAltName.uris.should == ["http://localhost.altname.example.com", "http://other.example.com"]
+    end
 
     it "should respond to :dns_names" do
       subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.new
@@ -67,6 +81,14 @@ describe CertificateAuthority::Extensions do
 
       subjectAltName.dns_names = ["localhost.altname.example.com", "other.example.com"]
       subjectAltName.to_s.should == "DNS:localhost.altname.example.com,DNS:other.example.com"
+    end
+
+    it "should parse DNS names from a proper OpenSSL extension string" do
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("DNS:localhost.altname.example.com", false)
+      subjectAltName.dns_names.should == ["localhost.altname.example.com"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("DNS:localhost.altname.example.com,DNS:other.example.com", false)
+      subjectAltName.dns_names.should == ["localhost.altname.example.com", "other.example.com"]
     end
 
     it "should respond to :ips" do
@@ -88,6 +110,14 @@ describe CertificateAuthority::Extensions do
       subjectAltName.to_s.should == "IP:1.2.3.4,IP:5.6.7.8"
     end
 
+    it "should parse IPs from a proper OpenSSL extension string" do
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("IP:1.2.3.4", false)
+      subjectAltName.ips.should == ["1.2.3.4"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("IP:1.2.3.4,IP:5.6.7.8", false)
+      subjectAltName.ips.should == ["1.2.3.4", "5.6.7.8"]
+    end
+
     it "should generate a proper OpenSSL extension string for URIs IPs and DNS names together" do
       subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.new
       subjectAltName.ips = ["1.2.3.4"]
@@ -107,9 +137,27 @@ describe CertificateAuthority::Extensions do
 
       subjectAltName.uris = ["http://localhost.altname.example.com", "http://other.altname.example.com"]
       subjectAltName.to_s.should == "URI:http://localhost.altname.example.com,URI:http://other.altname.example.com,DNS:localhost.altname.example.com,DNS:other.example.com,IP:1.2.3.4,IP:5.6.7.8"
-
     end
 
+    it "should parse URIs IPs and DNS names together from a proper OpenSSL extension string" do
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("IP:1.2.3.4", false)
+      subjectAltName.ips.should == ["1.2.3.4"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("DNS:localhost.altname.example.com,IP:1.2.3.4", false)
+      subjectAltName.dns_names.should == ["localhost.altname.example.com"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("DNS:localhost.altname.example.com,DNS:other.example.com,IP:1.2.3.4", false)
+      subjectAltName.dns_names.should == ["localhost.altname.example.com", "other.example.com"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("DNS:localhost.altname.example.com,DNS:other.example.com,IP:1.2.3.4,IP:5.6.7.8", false)
+      subjectAltName.ips.should == ["1.2.3.4", "5.6.7.8"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("URI:http://localhost.altname.example.com,DNS:localhost.altname.example.com,DNS:other.example.com,IP:1.2.3.4,IP:5.6.7.8", false)
+      subjectAltName.uris.should == ["http://localhost.altname.example.com"]
+
+      subjectAltName = CertificateAuthority::Extensions::SubjectAlternativeName.parse("URI:http://localhost.altname.example.com,URI:http://other.altname.example.com,DNS:localhost.altname.example.com,DNS:other.example.com,IP:1.2.3.4,IP:5.6.7.8", false)
+      subjectAltName.uris.should == ["http://localhost.altname.example.com", "http://other.altname.example.com"]
+    end
 
   end
 end

--- a/spec/units/signing_request_spec.rb
+++ b/spec/units/signing_request_spec.rb
@@ -63,24 +63,20 @@ EOF
       cert.should be_a(CertificateAuthority::Certificate)
     end
 
-    it "should not have a serial number set yet" do
-      @cert.serial_number.number.should be_nil
-    end
-
     it "should be signable w/ a serial number" do
-        root = CertificateAuthority::Certificate.new
-        root.signing_entity = true
-        root.subject.common_name = "chrischandler.name root"
-        root.key_material.generate_key(1024)
-        root.serial_number.number = 2
-        root.sign!
-        @cert.serial_number.number = 5
-        @cert.parent = root
-        result_cert = @cert.sign!
-        result_cert.should be_a(OpenSSL::X509::Certificate)
-        ## Verify the subjects and public key match
-        @csr.distinguished_name.to_x509_name.should == result_cert.subject
-        @csr.key_material.public_key.to_pem.should == result_cert.public_key.to_pem
+      root = CertificateAuthority::Certificate.new
+      root.signing_entity = true
+      root.subject.common_name = "chrischandler.name root"
+      root.key_material.generate_key(1024)
+      root.serial_number.number = 2
+      root.sign!
+      @cert.serial_number.number = 5
+      @cert.parent = root
+      result_cert = @cert.sign!
+      result_cert.should be_a(OpenSSL::X509::Certificate)
+      ## Verify the subjects and public key match
+      @csr.distinguished_name.to_x509_name.should == result_cert.subject
+      @csr.key_material.public_key.to_pem.should == result_cert.public_key.to_pem
     end
   end
 


### PR DESCRIPTION
I worked on a side project that used this gem, and I've now become too busy to continue working on this, but I at least wanted to submit a PR so that perhaps others could use some of the changes I made. Sorry that it's all in one commit and that it lacks complete tests. I wish I had more time. :(

List of various improvements:
- Use https:// for rubygems.org gem source
- Add activesupport gem for useful helper functions
- Cap not_before and not_after to the hour
- Use UTC for not_before and not_after
- Add support for setting the criticality of extensions
- Add support for producing a CSR based from an extension
- Add support for importing data from X.509 certificate
- Instead of having to list each extension manually, use ObjectSpace magic to dynamically find them
- Add support for parsing extension information from existing certificates
- Add new serialNumber option to the distinguished name
- Convert openssl_identifier method to use a constant
- Correct documentation for AuthorityKeyIdentifier
- Add support for caIssuers in AuthorityInfoAccess extension
- Remove clientAuth from default extendedKeyUsage extension usage
- Add support for deprecated nsComment and nsCertType extensions
- Initialize the serial_number to be a random number (2^128)
- Add support for parsing extension information from existing CSRs
- Require a private key before trying to produce a valid CSR
- Add/update some tests

TODO: Tests for all my changes

Anyway, best of luck!
