### PR TITLE
Fix method generation in WrappedDistinguishedName.

### DIFF
--- a/lib/certificate_authority/distinguished_name.rb
+++ b/lib/certificate_authority/distinguished_name.rb
@@ -67,12 +67,24 @@ module CertificateAuthority
   class WrappedDistinguishedName < DistinguishedName
     attr_accessor :x509_name
 
+    # this should by a String class extension, but this should be decided later
+    # implementation taken from ActiveSupport::Inflector
+    def underscore_string(camel_cased_word)
+      word = camel_cased_word.to_s.dup
+      word.gsub!('::', '/')
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      word.tr!("-", "_")
+      word.downcase!
+      word
+    end
+
     def initialize(x509_name)
       @x509_name = x509_name
 
       subject = @x509_name.to_a
       subject.each do |element|
-        field = element[0].downcase
+        field = underscore_string(element[0])
         value = element[1]
         #type = element[2] ## -not used
         method_sym = "#{field}=".to_sym

--- a/spec/units/distinguished_name_spec.rb
+++ b/spec/units/distinguished_name_spec.rb
@@ -12,6 +12,7 @@ describe CertificateAuthority::DistinguishedName do
     @distinguished_name.respond_to?(:o).should be_true
     @distinguished_name.respond_to?(:ou).should be_true
     @distinguished_name.respond_to?(:c).should be_true
+    @distinguished_name.respond_to?(:emailAddress).should be_true
   end
 
   it "should provide human-readable equivalents to the distinguished name common attributes" do
@@ -21,6 +22,7 @@ describe CertificateAuthority::DistinguishedName do
     @distinguished_name.respond_to?(:organization).should be_true
     @distinguished_name.respond_to?(:organizational_unit).should be_true
     @distinguished_name.respond_to?(:country).should be_true
+    @distinguished_name.respond_to?(:email_address).should be_true
   end
 
   it "should require a common name" do
@@ -37,7 +39,7 @@ describe CertificateAuthority::DistinguishedName do
 
   describe "from_openssl" do
     before do
-      subject = "/CN=justincummins.name/L=on my laptop/ST=relaxed/C=as/O=programmer/OU=using this code"
+      subject = "/CN=justincummins.name/L=on my laptop/ST=relaxed/C=as/O=programmer/OU=using this code/emailAddress=bob@example.de"
       @name = OpenSSL::X509::Name.parse subject
       @dn = CertificateAuthority::DistinguishedName.from_openssl @name
     end
@@ -46,7 +48,7 @@ describe CertificateAuthority::DistinguishedName do
       lambda { CertificateAuthority::DistinguishedName.from_openssl "Not a OpenSSL::X509::Name" }.should raise_error
     end
 
-    [:common_name, :locality, :state, :country, :organization, :organizational_unit].each do |field|
+    [:common_name, :locality, :state, :country, :organization, :organizational_unit, :email_address].each do |field|
       it "should set the #{field} attribute" do
         @dn.send(field).should_not be_nil
       end


### PR DESCRIPTION
Without this patch the initializer used downcase to cast the x509 subject entry into a method.
This led to emailAddress being converted to emailaddress, but the classes method is called email_address.
This patch introduces a underscore method that can convert camal-cased entries from x509 subects into
underscore instance methods.
Also added tests for email_address access to DistinguishedName unit tests
