### PR TITLE
use only the part of ActiveModel that are needed, so that all of ActiveSupport is not loaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'activemodel', ">= 3.0.6"
-gem 'activesupport', ">= 3.0.6"
 
 group :development do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,6 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel (>= 3.0.6)
-  activesupport (>= 3.0.6)
   coveralls
   jeweler (>= 1.5.2)
   rake

--- a/lib/certificate_authority.rb
+++ b/lib/certificate_authority.rb
@@ -2,7 +2,11 @@ $:.unshift(File.dirname(__FILE__)) unless $:.include?(File.dirname(__FILE__)) ||
 
 #Exterior requirements
 require 'openssl'
-require 'active_model'
+require 'active_model/callbacks'
+require 'active_model/naming'
+require 'active_model/translation'
+require 'active_model/validations'
+require 'active_model/serialization'
 
 #Internal modules
 require 'certificate_authority/signing_entity'

--- a/lib/certificate_authority/certificate.rb
+++ b/lib/certificate_authority/certificate.rb
@@ -1,5 +1,3 @@
-require 'active_support/all'
-
 module CertificateAuthority
   class Certificate
     include ActiveModel::Validations
@@ -34,8 +32,8 @@ module CertificateAuthority
       self.distinguished_name = DistinguishedName.new
       self.serial_number = SerialNumber.new
       self.key_material = MemoryKeyMaterial.new
-      self.not_before = Time.now.change(:min => 0).utc
-      self.not_after = Time.now.change(:min => 0).utc + 1.year
+      self.not_before = Time.now
+      self.not_after = Time.now + 60 * 60 * 24 * 365 # One year
       self.parent = self
       self.extensions = load_extensions()
 

--- a/lib/certificate_authority/extensions.rb
+++ b/lib/certificate_authority/extensions.rb
@@ -282,11 +282,11 @@ module CertificateAuthority
         return obj if value.nil?
         obj.critical = critical
         value.split("\n").each do |v|
-          if v.starts_with?("OCSP")
+          if v =~ /^OCSP/
             obj.ocsp << v.split.last
           end
 
-          if v.starts_with?("CA Issuers")
+          if v =~ /^CA Issuers/
             obj.ca_issuers << v.split.last
           end
         end

--- a/lib/certificate_authority/serial_number.rb
+++ b/lib/certificate_authority/serial_number.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module CertificateAuthority
   class SerialNumber
     include ActiveModel::Validations

--- a/spec/units/certificate_spec.rb
+++ b/spec/units/certificate_spec.rb
@@ -477,8 +477,8 @@ CERT
   end
 
   it "should default to one year validity" do
-    @certificate.not_after.should < Time.now.change(:min => 0).utc + 1.year + 2.hour and
-    @certificate.not_after.should > Time.now.change(:min => 0).utc + 1.year - 2.hour
+    @certificate.not_after.should < Time.now + 65 * 60 * 24 * 365 and
+    @certificate.not_after.should > Time.now + 55 * 60 * 24 * 365
   end
 
   it "should be able to have a revoked at time" do


### PR DESCRIPTION
closes #40 
