### PR TITLE
Fixes to use OpenSSL::Digest. 

### DIFF
--- a/lib/certificate_authority/certificate.rb
+++ b/lib/certificate_authority/certificate.rb
@@ -110,9 +110,9 @@ module CertificateAuthority
       end
 
       if signing_profile["digest"].nil?
-        digest = OpenSSL::Digest::Digest.new("SHA512")
+        digest = OpenSSL::Digest.new("SHA512")
       else
-        digest = OpenSSL::Digest::Digest.new(signing_profile["digest"])
+        digest = OpenSSL::Digest.new(signing_profile["digest"])
       end
 
       self.openssl_body = openssl_cert.sign(parent.key_material.private_key, digest)

--- a/lib/certificate_authority/certificate_revocation_list.rb
+++ b/lib/certificate_authority/certificate_revocation_list.rb
@@ -59,9 +59,9 @@ module CertificateAuthority
 
       signing_cert = OpenSSL::X509::Certificate.new(self.parent.to_pem)
       if signing_profile["digest"].nil?
-        digest = OpenSSL::Digest::Digest.new("SHA512")
+        digest = OpenSSL::Digest.new("SHA512")
       else
-        digest = OpenSSL::Digest::Digest.new(signing_profile["digest"])
+        digest = OpenSSL::Digest.new(signing_profile["digest"])
       end
       crl.issuer = signing_cert.subject
       self.crl_body = crl.sign(self.parent.key_material.private_key, digest)

--- a/lib/certificate_authority/signing_request.rb
+++ b/lib/certificate_authority/signing_request.rb
@@ -62,7 +62,7 @@ module CertificateAuthority
       opensslcsr.subject = @distinguished_name.to_x509_name
       opensslcsr.public_key = @key_material.public_key
       opensslcsr.attributes = @attributes unless @attributes.nil?
-      opensslcsr.sign @key_material.private_key, OpenSSL::Digest::Digest.new(@digest || "SHA512")
+      opensslcsr.sign @key_material.private_key, OpenSSL::Digest.new(@digest || "SHA512")
       opensslcsr
     end
 


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to use from very ancient era such as Ruby 1.8 
and finally was deprecated recently. https://github.com/ruby/ruby/pull/446
