### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -16,7 +17,7 @@ jobs:
           - '2.5'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    coderay (1.1.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -17,13 +16,9 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     json (2.3.0)
-    method_source (1.0.0)
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.5)
@@ -70,7 +65,6 @@ PLATFORMS
 DEPENDENCIES
   certificate_authority!
   coveralls
-  pry
   rake
   rspec
   rubocop

--- a/certificate_authority.gemspec
+++ b/certificate_authority.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler/setup'
 require 'certificate_authority'
 require 'pathname'
-require 'pry'
 
 require 'coveralls'
 Coveralls.wear!

--- a/spec/units/certificate_spec.rb
+++ b/spec/units/certificate_spec.rb
@@ -423,7 +423,8 @@ CERT
       expect(@cert_with_extensions.extensions["subjectKeyIdentifier"]).to eq(expected_subjectKeyIdentifier)
 
       expected_authorityKeyIdentifier = CertificateAuthority::Extensions::AuthorityKeyIdentifier.new
-      expected_authorityKeyIdentifier.identifier = "keyid:4C:58:CB:25:F0:41:4F:52:F4:28:C8:81:43:9B:A6:A8:A0:E6:92:E5"
+      keyid_prefix = Gem::Version.new(OpenSSL::VERSION) >= Gem::Version.new('3') ? '' : 'keyid:'
+      expected_authorityKeyIdentifier.identifier = "#{keyid_prefix}4C:58:CB:25:F0:41:4F:52:F4:28:C8:81:43:9B:A6:A8:A0:E6:92:E5"
       expect(@cert_with_extensions.extensions["authorityKeyIdentifier"]).to eq(expected_authorityKeyIdentifier)
 
       expected_authorityInfoAccess = CertificateAuthority::Extensions::AuthorityInfoAccess.new


### PR DESCRIPTION
Also updates the checkout action.

To get Ruby 3.2 to do the following:

1. Remove pry
2. Adjust the key identifier based on whether the OpenSSL version is pre-3 or a 3+ version.  The former has a `keyid:` prefix while the latter doesn't.

This runs green on my fork.